### PR TITLE
make shell lines in readme consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ There is an example Collection and Item for each VIIRS product supported by this
 
 ## Installation
 ```shell
-pip install stactools-viirs
+$ pip install stactools-viirs
 ```
 
 ## Command-line Usage


### PR DESCRIPTION
**Description:**

The `pip install` line in the readme does not contain a leading `$`, which is present in all other shell command examples. This adds it.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [ ] Examples have been updated to reflect changes, if applicable
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
