### PR TITLE
Remove Python 3.7 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
     defaults:
       run:
         shell: bash -l {0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Update Collection extents from Items and add an `eo:bands` list to appropriate Collection summaries. ([#13](https://github.com/stactools-packages/viirs/pull/13))
 
+### Removed
+
+- Removed Python 3.7 support ([#15](https://github.com/stactools-packages/viirs/pull/15))
+
 ## [0.1.0] - 2022-06-22
 
 Initial release.

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ keywords =
 classifiers =
     Development Status :: 4 - Beta
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
 


### PR DESCRIPTION
**Related Issue(s):**
None.

**Description:**
Removed Python 3.7 support to be compatible with stactools >= 0.4.0

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [ ] Examples have been updated to reflect changes, if applicable
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
